### PR TITLE
resolve #6: Model should support note duration

### DIFF
--- a/src/core/Common.cpp
+++ b/src/core/Common.cpp
@@ -153,12 +153,12 @@ static unsigned WAVE_PERIODS[] = {
 
 }
 
-unsigned noteToPulsePeriod(model::Note note)
+unsigned noteToPulsePeriod(model::NoteFrequency note)
 {
     return PULSE_PERIODS[(unsigned)note];
 }
 
-unsigned noteToWavePeriod(model::Note note)
+unsigned noteToWavePeriod(model::NoteFrequency note)
 {
     return WAVE_PERIODS[(unsigned)note];
 }

--- a/src/core/Common.h
+++ b/src/core/Common.h
@@ -2,5 +2,5 @@
 
 #include <model/Note.h>
 
-unsigned noteToPulsePeriod(model::Note note);
-unsigned noteToWavePeriod(model::Note note);
+unsigned noteToPulsePeriod(model::NoteFrequency note);
+unsigned noteToWavePeriod(model::NoteFrequency note);

--- a/src/core/NotePlayer.cpp
+++ b/src/core/NotePlayer.cpp
@@ -20,7 +20,7 @@ NotePlayer::NotePlayer(
 void NotePlayer::play(
     Channel channel,
     size_t instrument_index,
-    std::optional<model::Note> note)
+    std::optional<model::NoteFrequency> note)
 {
     auto& instrument = m_song_model->getInstrument(instrument_index);
     switch (channel) {
@@ -38,9 +38,27 @@ void NotePlayer::play(
     }
 }
 
+void NotePlayer::stop(
+    Channel channel)
+{
+    switch (channel) {
+    case Channel::Channel1:
+        stopChannel1();
+        break;
+    case Channel::Channel2:
+        stopChannel2();
+        break;
+    case Channel::Channel3:
+        stopChannel3();
+        break;
+    default:
+        break;
+    }
+}
+
 void NotePlayer::setChannel1Instrument(
     const model::PulseInstrument& pulse,
-    std::optional<model::Note> note)
+    std::optional<model::NoteFrequency> note)
 {
     const uint8_t register_10
         = (pulse.sweepPace() << 4)
@@ -73,7 +91,6 @@ void NotePlayer::setChannel1Instrument(
 
         const auto register_14
             = 0x80
-            | (pulse.lengthEnable() << 6)
             | (period >> 8);
 
         m_audio_processing_unit->updateRegister(
@@ -81,7 +98,7 @@ void NotePlayer::setChannel1Instrument(
             register_14);
     } else {
         const auto register_14
-            = (pulse.lengthEnable() << 6);
+            = 0;
 
         m_audio_processing_unit->updateRegister(
             Register::NR14,
@@ -92,7 +109,7 @@ void NotePlayer::setChannel1Instrument(
 
 void NotePlayer::setChannel2Instrument(
     const model::PulseInstrument& pulse,
-    std::optional<model::Note> note)
+    std::optional<model::NoteFrequency> note)
 {
     const uint8_t register_21
         = ((unsigned)pulse.dutyCycle() << 6)
@@ -117,15 +134,13 @@ void NotePlayer::setChannel2Instrument(
 
         const auto register_24
             = 0x80
-            | (pulse.lengthEnable() << 6)
             | (period >> 8);
 
         m_audio_processing_unit->updateRegister(
             Register::NR24,
             register_24);
     } else {
-        const auto register_24
-            = (pulse.lengthEnable() << 6);
+        const auto register_24 = 0;
 
         m_audio_processing_unit->updateRegister(
             Register::NR24,
@@ -136,7 +151,7 @@ void NotePlayer::setChannel2Instrument(
 
 void NotePlayer::setChannel3Instrument(
     const model::WaveInstrument& wave,
-    std::optional<model::Note> note)
+    std::optional<model::NoteFrequency> note)
 {
     // ugly comparison, should we try to compare by instrument index ?
     if (wave != m_wave) {
@@ -167,12 +182,35 @@ void NotePlayer::setChannel3Instrument(
 
         const uint8_t nr34
             = 0x80
-            | (wave.lengthEnable() << 6)
             | (period >> 8);
 
         m_audio_processing_unit->updateRegister(
             Register::NR34, nr34);
     }
+}
+
+void NotePlayer::stopChannel1()
+{
+    const uint8_t register_12 = 0; // Set initial volume to 0, decrease env dir so the sound is muted
+    const uint8_t register_14 = 0x80; // Trigger
+    m_audio_processing_unit->updateRegister(Register::NR12, register_12);
+    m_audio_processing_unit->updateRegister(Register::NR14, register_14);
+}
+
+void NotePlayer::stopChannel2()
+{
+    const uint8_t register_22 = 0; // Set initial volume to 0, decrease env dir so the sound is muted
+    const uint8_t register_24 = 0x80; // Trigger
+    m_audio_processing_unit->updateRegister(Register::NR22, register_22);
+    m_audio_processing_unit->updateRegister(Register::NR24, register_24);
+}
+
+void NotePlayer::stopChannel3()
+{
+    const uint8_t register_32 = 0; // Set initial volume to 0, decrease env dir so the sound is muted
+    const uint8_t register_34 = 0x80; // Trigger
+    m_audio_processing_unit->updateRegister(Register::NR32, register_32);
+    m_audio_processing_unit->updateRegister(Register::NR34, register_34);
 }
 
 }

--- a/src/core/NotePlayer.h
+++ b/src/core/NotePlayer.h
@@ -27,22 +27,26 @@ public:
     void play(
         Channel channel,
         size_t instrument_index,
-        std::optional<model::Note> note);
+        std::optional<model::NoteFrequency> note);
 
     void stop(Channel channel);
 
 private:
     void setChannel1Instrument(
         const model::PulseInstrument& pulse,
-        std::optional<model::Note> note);
+        std::optional<model::NoteFrequency> note);
 
     void setChannel2Instrument(
         const model::PulseInstrument& pulse,
-        std::optional<model::Note> note);
+        std::optional<model::NoteFrequency> note);
 
     void setChannel3Instrument(
         const model::WaveInstrument& wave,
-        std::optional<model::Note> note);
+        std::optional<model::NoteFrequency> note);
+
+    void stopChannel1();
+    void stopChannel2();
+    void stopChannel3();
 
     std::shared_ptr<model::Song> m_song_model;
     std::shared_ptr<IAudioProcessingUnit> m_audio_processing_unit;

--- a/src/core/SongPlayer.h
+++ b/src/core/SongPlayer.h
@@ -8,7 +8,6 @@ namespace model {
 class Chain;
 class Phrase;
 class Song;
-enum class Note;
 }
 
 class IAudioProcessingUnit;
@@ -29,7 +28,6 @@ public:
 
     ~SongPlayer();
 
-    void playNote(model::Note note, size_t instrument_index);
     void playSong();
     void stop();
 

--- a/src/core/song_loader/JsonSongLoader.cpp
+++ b/src/core/song_loader/JsonSongLoader.cpp
@@ -51,13 +51,16 @@ static void loadPhrases(
         auto& phrase_model = song.getPhrase(phrase_index);
         size_t note_index = 0;
         for (const auto& note : phrase) {
-            const auto note_value = getJsonValue<model::Note>(note, "note");
+            const auto frequency = getJsonValue<model::NoteFrequency>(note, "frequency");
             const auto instrument_index = getJsonValue<size_t>(note, "instrument_index");
-            if (note_value) {
-                phrase_model.setNote(note_index, *note_value);
-            }
-            if (instrument_index) {
-                phrase_model.setInstrumentIndex(note_index, *instrument_index);
+            const auto duration = getJsonValue<size_t>(note, "duration");
+            if (frequency && instrument_index && duration) {
+                phrase_model.setNote(
+                    note_index,
+                    model::Note {
+                        *frequency,
+                        *duration,
+                        *instrument_index });
             }
             ++note_index;
             if (note_index == model::Phrase::NOTE_COUNT) {

--- a/src/core/song_saver/JsonSongSaver.cpp
+++ b/src/core/song_saver/JsonSongSaver.cpp
@@ -21,15 +21,12 @@ static void savePhrases(
         for (auto note_index = 0u; note_index < model::Phrase::NOTE_COUNT; ++note_index) {
             const auto note_value = phrase.note(note_index);
             if (note_value.has_value()) {
-                json_note["note"] = static_cast<int>(
-                    *note_value);
+                json_note["frequency"] = note_value->frequency();
+                json_note["duration"] = note_value->duration();
+                json_note["instrument_index"] = note_value->instrumentIndex();
             } else {
-                json_note["note"] = nullptr;
-            }
-            const auto instrument_index = phrase.instrumentIndex(note_index);
-            if (instrument_index.has_value()) {
-                json_note["instrument_index"] = *instrument_index;
-            } else {
+                json_note["frequency"] = nullptr;
+                json_note["duration"] = nullptr;
                 json_note["instrument_index"] = nullptr;
             }
             json_phrase.push_back(json_note);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -192,7 +192,7 @@ int MainWindow::execute()
     SDL_Quit();
 
     core::song_saver::JsonSongSaver saver;
-    // saver.saveSong(*song_model, TEMP_SONG_FILE);
+    saver.saveSong(*song_model, TEMP_SONG_FILE);
 
     return 0;
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -192,7 +192,7 @@ int MainWindow::execute()
     SDL_Quit();
 
     core::song_saver::JsonSongSaver saver;
-    saver.saveSong(*song_model, TEMP_SONG_FILE);
+    // saver.saveSong(*song_model, TEMP_SONG_FILE);
 
     return 0;
 }

--- a/src/gui/views/PatternView.cpp
+++ b/src/gui/views/PatternView.cpp
@@ -32,10 +32,10 @@ PatternView::PatternView(
                 auto current_note = phrase.note(i);
                 if (!current_note.has_value())
                     continue;
-                if (!lowest_note.has_value() || *current_note < *lowest_note) {
+                if (!lowest_note.has_value() || current_note->frequency() < lowest_note->frequency()) {
                     lowest_note = *current_note;
                 }
-                if (!highest_note.has_value() || *current_note > *highest_note) {
+                if (!highest_note.has_value() || current_note->frequency() > highest_note->frequency()) {
                     highest_note = *current_note;
                 }
             }
@@ -45,10 +45,10 @@ PatternView::PatternView(
             }
             if (!lowest_note.has_value()
                 || !highest_note.has_value()
-                || int(*highest_note) - int(*lowest_note) < 7) {
+                || int(highest_note->frequency()) - int(lowest_note->frequency()) < 7) {
                 scale = 8;
             } else {
-                scale = int(*highest_note) - int(*lowest_note) + 1;
+                scale = int(highest_note->frequency()) - int(lowest_note->frequency()) + 1;
             }
 
             const int note_height = height / scale;
@@ -60,9 +60,11 @@ PatternView::PatternView(
                     continue;
                 }
                 rectangle.x = note_width * i;
-                rectangle.y = height - ((int(*current_note) - int(*lowest_note) + 1) * note_height);
+                rectangle.y
+                    = height
+                    - ((int(current_note->frequency()) - int(lowest_note->frequency()) + 1) * note_height);
                 rectangle.h = note_height;
-                rectangle.w = note_width;
+                rectangle.w = note_width * current_note->duration();
 
                 painter.fillRectangle(
                     rectangle,

--- a/src/gui/views/PianoRollView.cpp
+++ b/src/gui/views/PianoRollView.cpp
@@ -105,7 +105,11 @@ PianoRollView::PianoRollView(
 
     view_widget.onPressed(ecs::Button::Left, [this](ecs::Button, int x, int y) {
         size_t note = ((viewHeight() - y - m_y_offset) / BLACK_KEY_HEIGHT);
-        m_note_player->play(Channel::Channel1, 0, model::Note(note));
+        m_note_player->play(Channel::Channel2, 0, model::NoteFrequency(note));
+    });
+
+    view_widget.onReleased(ecs::Button::Left, [this](ecs::Button, int, int) {
+        m_note_player->stop(Channel::Channel2);
     });
 }
 

--- a/src/gui/views/PianoRollView.cpp
+++ b/src/gui/views/PianoRollView.cpp
@@ -105,11 +105,11 @@ PianoRollView::PianoRollView(
 
     view_widget.onPressed(ecs::Button::Left, [this](ecs::Button, int x, int y) {
         size_t note = ((viewHeight() - y - m_y_offset) / BLACK_KEY_HEIGHT);
-        m_note_player->play(Channel::Channel2, 0, model::NoteFrequency(note));
+        m_note_player->play(Channel::Channel1, 0, model::NoteFrequency(note));
     });
 
     view_widget.onReleased(ecs::Button::Left, [this](ecs::Button, int, int) {
-        m_note_player->stop(Channel::Channel2);
+        m_note_player->stop(Channel::Channel1);
     });
 }
 

--- a/src/gui/views/SequencerView.cpp
+++ b/src/gui/views/SequencerView.cpp
@@ -41,9 +41,11 @@ SequencerView::SequencerView(
     std::shared_ptr<model::Song> song_model)
     : m_sequencer_widget(sequencer_view_widget)
     , m_progression_bar_widget(progression_bar_widget)
+    , m_current_track_index(0)
     , m_x_offset(0)
     , m_y_offset(0)
-    , m_current_track_index(0)
+    , m_last_note_index(0)
+    , m_last_phrase_index(0)
 {
     sequencer_view_widget.onDraw(
         [sequencer_view_widget, this, song_model](
@@ -84,21 +86,29 @@ SequencerView::SequencerView(
 
             // Draw notes
             SDL_Rect rect;
-            rect.w = CELL_WIDTH;
             rect.h = CELL_HEIGHT;
             for (int i = 0; i < draw_cells_on_row; i++) {
                 const int current_phrase = (i + start_i) / NOTES_BY_PHRASE;
                 const int current_note_index = (i + start_i) % NOTES_BY_PHRASE;
 
-                auto phrase_index = song_model->getTrack(m_current_track_index).phraseIndex(current_phrase);
+                auto phrase_index
+                    = song_model->getTrack(
+                                    m_current_track_index)
+                          .phraseIndex(current_phrase);
                 if (!phrase_index.has_value())
                     continue;
 
-                const auto note = song_model->getPhrase(*phrase_index).note(current_note_index);
+                const auto note
+                    = song_model->getPhrase(
+                                    *phrase_index)
+                          .note(current_note_index);
+
                 if (!note.has_value())
                     continue;
+
                 rect.x = i * (CELL_WIDTH + CELL_SPACING) - start_x_offset;
-                rect.y = ((6 * 12 - int(*note)) - 1) * (CELL_HEIGHT + CELL_SPACING) - m_y_offset;
+                rect.y = ((6 * 12 - int(note->frequency())) - 1) * (CELL_HEIGHT + CELL_SPACING) - m_y_offset;
+                rect.w = (CELL_WIDTH + CELL_SPACING) * note->duration();
                 painter.fillRectangle(rect, graphics::core::Color::fromHexa("#ff0000"));
             }
         });

--- a/src/model/Note.cpp
+++ b/src/model/Note.cpp
@@ -19,19 +19,19 @@ static std::array<std::string, 12> NOTE_PREFIXES = {
     "B"
 };
 
-static std::string getNotePrefix(Note note)
+static std::string getNotePrefix(NoteFrequency note)
 {
     unsigned index = static_cast<unsigned>(note) % 12;
     return NOTE_PREFIXES[index];
 }
 
-static std::string getOctave(Note note)
+static std::string getOctave(NoteFrequency note)
 {
     unsigned index = static_cast<unsigned>(note) / 12;
     return std::to_string(index + 2);
 }
 
-static std::string getNoteSuffix(Note note)
+static std::string getNoteSuffix(NoteFrequency note)
 {
     unsigned index = static_cast<unsigned>(note) % 12;
     if (index == 1 || index == 3 || index == 6 || index == 8 || index == 10) {
@@ -40,9 +40,49 @@ static std::string getNoteSuffix(Note note)
     return "";
 }
 
-std::string to_string(Note note)
+std::string to_string(NoteFrequency note)
 {
     return getNotePrefix(note) + getOctave(note) + getNoteSuffix(note);
+}
+
+Note::Note(
+    NoteFrequency frequency,
+    size_t duration,
+    size_t instrument_index)
+    : m_frequency(frequency)
+    , m_duration(duration)
+    , m_instrument_index(instrument_index)
+{
+}
+
+NoteFrequency Note::frequency() const
+{
+    return m_frequency;
+}
+
+size_t Note::duration() const
+{
+    return m_duration;
+}
+
+size_t Note::instrumentIndex() const
+{
+    return m_instrument_index;
+}
+
+void Note::setFrequency(NoteFrequency frequency)
+{
+    m_frequency = frequency;
+}
+
+void Note::setDuration(size_t duration)
+{
+    m_duration = duration;
+}
+
+void Note::setInstrumentIndex(size_t instrument_index)
+{
+    m_instrument_index = instrument_index;
 }
 
 }

--- a/src/model/Note.h
+++ b/src/model/Note.h
@@ -4,7 +4,7 @@
 
 namespace model {
 
-enum class Note {
+enum class NoteFrequency {
     C2,
     C2Sharp,
     D2,
@@ -67,6 +67,28 @@ enum class Note {
     B6,
 };
 
-std::string to_string(Note note);
+std::string to_string(NoteFrequency note);
+
+class Note {
+public:
+    Note() = default;
+    Note(
+        NoteFrequency frequency,
+        size_t duration,
+        size_t instrument_index);
+
+    NoteFrequency frequency() const;
+    size_t duration() const;
+    size_t instrumentIndex() const;
+
+    void setFrequency(NoteFrequency frequency);
+    void setDuration(size_t duration);
+    void setInstrumentIndex(size_t instrument_index);
+
+private:
+    NoteFrequency m_frequency;
+    size_t m_duration;
+    size_t m_instrument_index;
+};
 
 }

--- a/src/model/Phrase.cpp
+++ b/src/model/Phrase.cpp
@@ -4,32 +4,17 @@ namespace model {
 
 std::optional<Note> Phrase::note(size_t index) const
 {
-    return m_elements[index].note;
+    return m_notes[index];
 }
 
 void Phrase::setNote(size_t index, Note note)
 {
-    m_elements[index].note = note;
+    m_notes[index] = note;
 }
 
 void Phrase::clearNote(size_t index)
 {
-    m_elements[index].note.reset();
-}
-
-std::optional<size_t> Phrase::instrumentIndex(size_t index) const
-{
-    return m_elements[index].instrument_index;
-}
-
-void Phrase::setInstrumentIndex(size_t index, size_t instrument_index)
-{
-    m_elements[index].instrument_index = instrument_index;
-}
-
-void Phrase::clearInstrumentIndex(size_t index)
-{
-    m_elements[index].instrument_index.reset();
+    m_notes[index].reset();
 }
 
 }

--- a/src/model/Phrase.h
+++ b/src/model/Phrase.h
@@ -15,16 +15,8 @@ public:
     void clearNote(size_t index);
     std::optional<Note> note(size_t index) const;
 
-    void setInstrumentIndex(size_t index, size_t instrument_index);
-    void clearInstrumentIndex(size_t index);
-    std::optional<size_t> instrumentIndex(size_t index) const;
-
 private:
-    struct PhraseElement {
-        std::optional<Note> note;
-        std::optional<size_t> instrument_index;
-    };
-    std::array<PhraseElement, NOTE_COUNT> m_elements;
+    std::array<std::optional<Note>, NOTE_COUNT> m_notes;
 };
 
 }


### PR DESCRIPTION
- Change model's `Note` enum to class
- Note has duration and instrument index
- Change `NotePlayer` so it can play note as long as defined duration
- Change Sequencer and Song view to display note durations
- Change Json loader/saver to include duration and instrument index